### PR TITLE
ci: sync codeql-action pins and fix dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,6 @@ updates:
           - "github/codeql-action"
           - "step-security/*"
           - "gitleaks/*"
-        update-types:
-          - "minor"
-          - "patch"
       # CI/CD actions
       ci-actions:
         patterns:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,13 +61,13 @@ jobs:
       # - PSScriptAnalyzer in ci.yml (lint and security rules)
       # - Custom security checks in security.yml (hardcoded secrets, unsafe patterns)
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@9cea5827c668a1fe7165dbce6e80c3f9cf3f83ac # v4
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: actions
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@9cea5827c668a1fe7165dbce6e80c3f9cf3f83ac # v4
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:actions"
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -118,7 +118,7 @@ jobs:
           mv results.tmp results.sarif
 
       - name: Upload to Code Scanning
-        uses: github/codeql-action/upload-sarif@9cea5827c668a1fe7165dbce6e80c3f9cf3f83ac # v4
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           sarif_file: results.sarif
           category: scorecard

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -282,7 +282,7 @@ jobs:
           }
 
       - name: Upload SARIF results
-        uses: github/codeql-action/upload-sarif@9cea5827c668a1fe7165dbce6e80c3f9cf3f83ac # v4
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         if: always()
         with:
           sarif_file: security-results.sarif


### PR DESCRIPTION
## Summary

Fixes CodeQL version desync and the Dependabot grouping that causes it. Functional changes only.

### Task 1 — CodeQL action version sync
All four `github/codeql-action/*` references were pinned to an older commit (`9cea5827`) carrying a **bare `# v4`** comment. The bare-major comment makes Dependabot treat each bump as an opaque *digest* update, which escapes the group's `update-types` filter and opens **separate per-sub-action PRs** — desyncing init/analyze/upload-sarif and breaking CodeQL runs (`Loaded a configuration file for version 'X', but running version 'Y'`).

Repinned all four to the current tip of the `v4` major, with a specific-version comment:

```
54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
```

| File | Ref |
|------|-----|
| `.github/workflows/codeql.yml` | `init`, `analyze` |
| `.github/workflows/scorecard.yml` | `upload-sarif` |
| `.github/workflows/security.yml` | `upload-sarif` |

Removed the `update-types: [minor, patch]` filter from the `security-actions` Dependabot group (which matches `github/codeql-action`) so **all** update types — including digest and major — stay grouped and the sub-actions always bump together in one PR.

### Task 2 — Divergent SHAs
Audited every SHA-pinned action grouped by `owner/repo`. **No action was pinned to more than one distinct SHA** — no changes needed.

### Superseded Dependabot PRs
These open PRs each bump a single codeql sub-action separately (the desync symptom) and are superseded by this PR — safe to close:
- #51 `github/codeql-action/upload-sarif`
- #52 `github/codeql-action/init`
- #53 `github/codeql-action/analyze`

## Type of change
CI / supply-chain hardening. No runtime code touched.

## Testing
- All edited YAML validated with `yaml.safe_load`.
- Post-edit divergence audit: every `owner/repo` maps to exactly one SHA.
- Version facts resolved via the GitHub API (`v4` tip → `54f647b7` → `v4.36.3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)