### PR TITLE
ci: correct dependency-review-action version comment to v5.0.0

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -50,7 +50,7 @@ jobs:
           persist-credentials: false
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v4.7.1
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           config-file: .github/dependency-review-config.yml
 


### PR DESCRIPTION
## Summary

Cosmetic, comment-only correction of a stale version comment (Task 3). No SHA changes, no behavior change.

`actions/dependency-review-action` in `.github/workflows/security.yml` is pinned to `a1d282b36b6f3519aa1f3fc636f609c47dddb294`, which resolves to tag **`v5.0.0`** — but the trailing comment read `# v4.7.1`. (`v4.7.1` is a *different* commit, `da24556b`.)

```diff
- uses: actions/dependency-review-action@a1d282b3... # v4.7.1
+ uses: actions/dependency-review-action@a1d282b3... # v5.0.0
```

This is the dangerous class of stale comment: it hides that the pinned SHA has already crossed a **major-version boundary** (v4 → v5). Corrected to match the SHA's real version.

### Scope note
Every other SHA-pinned action across all workflows was verified against the GitHub API and already carries a correct `# vX.Y.Z` comment — this was the only mismatch not already handled by the functional PR (#54).

## Type of change
CI / documentation accuracy. Comment only — the pinned SHA is unchanged.

## Testing
- `security.yml` validated with `yaml.safe_load`.
- Version resolved via GitHub API: tag `v5.0.0` → `a1d282b3` (matches pin); tag `v4.7.1` → `da24556b` (different commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)